### PR TITLE
ensure pg_hba.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,34 @@ postgresql_pid_dir: "/run/postgresql"
 postgresql_pid_file: "{{ postgresql_version }}-{{postgresql_cluster_name}}.pid"
 postgresql_cluster_dir: "{{ postgresql_version }}/{{ postgresql_cluster_name }}"
 
+postgresql_pg_hba_default:
+  - type: local
+    database: all
+    user: "{{ postgresql_user }}"
+    address: ""
+    method: "peer"
+  - type: local
+    database: all
+    user: "{{ postgresql_user }}"
+    address: ""
+    method: "peer map={{ postgresql_user }}"
+  - type: local
+    database: all
+    user: all
+    address: ""
+    method: "md5"
+  - type: host
+    database: all
+    user: all
+    address: "127.0.0.1/32"
+    method: "md5"
+postgresql_pg_hba:
+  - type: host
+    database: all
+    user: all
+    address: "0.0.0.0/0"
+    method: "md5"
+
 postgresql_pg_ident:
   - mapname: "{{ postgresql_user }}"
     system_username: "{{ postgresql_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     - import_tasks: packages.yml
     - import_tasks: directories.yml
     - import_tasks: postgresql.conf.yml
+    - import_tasks: pg_hba.conf.yml
     - import_tasks: pg_ident.conf.yml
   tags:
     - postgresql

--- a/tasks/pg_hba.conf.yml
+++ b/tasks/pg_hba.conf.yml
@@ -1,0 +1,10 @@
+---
+- name: ensure pg_hba.conf
+  template:
+    src: pg_hba.conf.j2
+    dest: "{{ postgresql_hba_file }}"
+    owner: "{{ postgresql_user }}"
+    group: "{{ postgresql_group }}"
+    mode: 0640
+  become: true
+  register: postgresql_pg_hba_conf

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+{% for connection in postgresql_pg_hba_default %}
+{{ connection.type }} {{ connection.database }} {{ connection.user }} {{ connection.address }} {{ connection.method }}
+{% endfor %}
+
+{% for connection in postgresql_pg_hba %}
+{{ connection.type }} {{ connection.database }} {{ connection.user }} {{ connection.address }} {{ connection.method }}
+{% endfor %}


### PR DESCRIPTION
permit local connections for postgres by peer (by default)
allow localhost and socket connections with md5 auth (by default)
allow connections from everywhere with md5 auth (for user to override)